### PR TITLE
Un-yield `yield return` and `yield break` uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ logger.Information("Hello from the FiveM client!");
 - [#1](https://github.com/Twinki14/CitizenFX.Extensions.Client.Serilog/pull/1) - Trim files, remove assembly signing, only target net452
 - [#2](https://github.com/Twinki14/CitizenFX.Extensions.Client.Serilog/pull/2) - Add CI/CD proceeded by fix [in #4](https://github.com/Twinki14/CitizenFX.Extensions.Client.Serilog/pull/4)
 - [#3](https://github.com/Twinki14/CitizenFX.Extensions.Client.Serilog/pull/3) - Remove extra performance tests & results, this just bloated things for the purpose of this fork
+- [#5](https://github.com/Twinki14/CitizenFX.Extensions.Client.Serilog/pull/5) - Un-yield `yield return` and `yield break` uses
 
 ## Notes
 - This fork is in **NO WAY** affiliated with the [Serilog Organization](https://github.com/serilog) or the [Serilog project](https://serilog.net/), it's purely a fork to provide compatability with FiveM's client-resource shipped mono

--- a/src/Serilog/Capturing/GetablePropertyFinder.cs
+++ b/src/Serilog/Capturing/GetablePropertyFinder.cs
@@ -19,28 +19,32 @@ static class GetablePropertyFinder
     internal static IEnumerable<PropertyInfo> GetPropertiesRecursive(this Type type)
     {
         var seenNames = new HashSet<string>();
+        var result = new List<PropertyInfo>();
 
         var currentTypeInfo = type.GetTypeInfo();
 
         while (currentTypeInfo.AsType() != typeof(object))
         {
-            var unseenProperties = currentTypeInfo.DeclaredProperties.Where(p => p.CanRead &&
-                                                                                 p.GetMethod!.IsPublic && !p.GetMethod.IsStatic &&
-                                                                                 (p.Name != "Item" || p.GetIndexParameters().Length == 0) && !seenNames.Contains(p.Name));
+            var unseenProperties = currentTypeInfo.DeclaredProperties
+                .Where(p => p.CanRead &&
+                            p.GetMethod!.IsPublic && !p.GetMethod.IsStatic &&
+                            (p.Name != "Item" || p.GetIndexParameters().Length == 0) && !seenNames.Contains(p.Name));
 
             foreach (var propertyInfo in unseenProperties)
             {
                 seenNames.Add(propertyInfo.Name);
-                yield return propertyInfo;
+                result.Add(propertyInfo);
             }
 
             var baseType = currentTypeInfo.BaseType;
             if (baseType == null)
             {
-                yield break;
+                return result;
             }
 
             currentTypeInfo = baseType.GetTypeInfo();
         }
+
+        return result;
     }
 }

--- a/src/Serilog/Parsing/MessageTemplateParser.cs
+++ b/src/Serilog/Parsing/MessageTemplateParser.cs
@@ -38,10 +38,12 @@ public class MessageTemplateParser : IMessageTemplateParser
 
     static IEnumerable<MessageTemplateToken> Tokenize(string messageTemplate)
     {
+        var result = new List<MessageTemplateToken>();
+
         if (messageTemplate.Length == 0)
         {
-            yield return new TextToken("", 0);
-            yield break;
+            result.Add(new TextToken("", 0));
+            return result;
         }
 
         var nextIndex = 0;
@@ -50,18 +52,18 @@ public class MessageTemplateParser : IMessageTemplateParser
             var beforeText = nextIndex;
             var tt = ParseTextToken(nextIndex, messageTemplate, out nextIndex);
             if (nextIndex > beforeText)
-                yield return tt;
+                result.Add(tt);
 
             if (nextIndex == messageTemplate.Length)
-                yield break;
+                return result;
 
             var beforeProp = nextIndex;
             var pt = ParsePropertyToken(nextIndex, messageTemplate, out nextIndex);
             if (beforeProp < nextIndex)
-                yield return pt;
+                result.Add(pt);
 
             if (nextIndex == messageTemplate.Length)
-                yield break;
+                return result;
         }
     }
 

--- a/src/Serilog/Serilog.csproj
+++ b/src/Serilog/Serilog.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Simple .NET logging with fully-structured events</Description>
-    <Authors>Serilog Contributors;Twinki14</Authors>
+    <Authors>Serilog Contributors, made FiveM compatable by Twinki</Authors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>serilog;logging;semantic;structured;fivem;cfx-extensions</PackageTags>
     <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
# Motivations
`yield return` and `yield break` are not compatible in mono, they must be un-yielded for compatibility with FiveM